### PR TITLE
Many stylistic changes to enhance code readability

### DIFF
--- a/lib/MojoX/JSON/RPC/Simple/Service.pm
+++ b/lib/MojoX/JSON/RPC/Simple/Service.pm
@@ -9,8 +9,13 @@ MojoX::JSON::RPC::Simple::Service - Base class for RPC Services
 
 This object represent a base class for RPC Services.
 It only ovverides the C<new> to inject C<'with_mojo_tx'=1> option by default.
-For more information on how services work, have a look at L<MojoX::JSON::RPC::Service>.
-Every function that starts with C<rpc_> it's automatically registered as an rpc service, this means that on your service file you must only add git remote add origin https://github.com/IntelliHome/MojoX-JSON-RPC-Simple.gitC<__PACKAGE__->register_rpc;> at the bottom of the code.
+For more information on how services work, have a look at
+L<MojoX::JSON::RPC::Service>.
+
+Every function that starts with C<rpc_> it's automatically registered as an
+rpc service, this means that on your service file you must only add git remote
+add origin https://github.com/IntelliHome/MojoX-JSON-RPC-Simple.git
+C<__PACKAGE__->register_rpc;> at the bottom of the code.
 
 =head1 SEE ALSO
 
@@ -19,43 +24,57 @@ L<MojoX::JSON::RPC::Simple>, L<MojoX::JSON::RPC::Service>
 =cut
 
 sub new {
-    my $self = shift;
-    $self = $self->SUPER::new(@_);
-    $self->{'_rpcs'}->{$_}->{'with_mojo_tx'}
-        = $self->{'_rpcs'}->{$_}->{'with_svc_obj'}
-        = $self->{'_rpcs'}->{$_}->{'with_self'} = 1
-        for ( keys %{ $self->{'_rpcs'} } );
+    my ( $self, @params ) = @_;
+
+    $self = $self->SUPER::new(@params);
+
+    foreach my $method ( keys %{ $self->{'_rpcs'} } ) {
+        $self->{'_rpcs'}->{$method}->{'with_mojo_tx'} = 1;
+        $self->{'_rpcs'}->{$method}->{'with_svc_obj'} = 1;
+        $self->{'_rpcs'}->{$method}->{'with_self'}    = 1;
+    }
+
     return $self;
 }
 
 sub register_rpc {
-    __PACKAGE__->MojoX::JSON::RPC::Simple::Service::register_rpc_regex(
-        qr/^rpc\_/, (caller)[0] );
+    my $caller_package_name = caller;
+
+    MojoX::JSON::RPC::Simple::Service->register_rpc_regex(
+            qr/^ rpc _ /x,
+            $caller_package_name,
+        );
 }
 
 sub register_rpc_suffix {
-    shift;
-    my $suffix = shift;
-    __PACKAGE__->MojoX::JSON::RPC::Simple::Service::register_rpc_regex(
-        qr/^$suffix\_/, (caller)[0] );
+    my ( undef, $suffix ) = @_;
+
+    my $caller_package_name = caller;
+
+    MojoX::JSON::RPC::Simple::Service->register_rpc_regex(
+            qr/^ $suffix _ /x,
+            $caller_package_name,
+        );
 }
 
 sub register_rpc_regex {
-    shift;
-    my $r = shift;
-    my $p = shift // caller;
-    my $symbol = { eval( '%' . $p . "::" ) };
-    local @_;
-    foreach my $entry ( keys %{$symbol} ) {
-        no strict 'refs';
-        if ( defined &{ $p . "::$entry" } ) {
-            push( @_, $entry )
-                if $entry =~ $r
-                ; # this allows functions that match the regex to be automatically exported as rpc public services
+    my ( undef, $regex, $package ) = @_;
+    $package = caller if (! defined($package) );
+
+    my @methods = ();
+    my $symbols = {
+        eval( '%' . $package . '::' )
+    };
+
+    foreach my $entry ( keys %{ $symbols } ) {
+        # this allows functions that match the regex to be automatically
+        # exported as rpc public services
+        if ( defined($package->can($entry)) && ($entry =~ $regex) ) {
+            push( @methods, $entry );
         }
     }
-    use strict 'refs';
-    $p->register_rpc_method_names(@_);
+
+    $package->register_rpc_method_names(@methods);
 }
 
 1;


### PR DESCRIPTION
- Removed overriding @_ with 'local @_'.
- shift no longer unpacks sub args.
- Got rid of using **PACKAGE**, $_, (caller)[0] and friends.
- Use x modifier for regexes.
- Replaced $p, $r and other variables with meaningful names.
